### PR TITLE
doc: マイナポータルのモックAPIの詳細を更新

### DIFF
--- a/docs/apiDoc.yaml
+++ b/docs/apiDoc.yaml
@@ -24,26 +24,26 @@ paths:
           name: req
           schema:
             type: string
-            example: "name+add+money"
-          description: "取得したい情報を＋区切りで指定する"
+            example: "income,pension,account"
+          description: "取得したい情報をカンマ区切りで指定する"
       responses:
         '200':
-          description: "正常に取得した情報を返却する。存在しない項目はレスポンスしない。"
+          description: "正常に取得した情報を返却する。存在しない項目はレスポンスしない。また、各レスポンスのフォーマットはマイナポータルAPIの仕様公開ページを参照。"
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  name:
-                    type: string
-                    example: "山田 太郎"
-                  add:
-                    type: string
-                    example: "東京都中央区"
-                  money:
-                    type: integer
-                    format: int64
-                    example: 100000000
+                  income:
+                    type: object
+                  pension:
+                    type: object
+                  account:
+                    type: object
+                  residentCard:
+                    type: object
+                  specialHealth:
+                    type: object
   /data:
     get:
       tags:


### PR DESCRIPTION
## 関連する issue\*
#39 

## 作業内容\*

<!-- 変更箇所および内容 -->
以下のAPIが：以降のクエリで取得できる。
- 所得・個人住民税情報API：income
- 国民年金・被用者年金の給付・保険料徴収の情報API：pension
- 銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報API：account
- 住民票関係情報API：residentCard
- 特定健診情報API：specialHealth

## チェックリスト\*

- [x] 新規でのバグ・警告等がログに表示されていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [x] この変更が他に影響を及ぼしていない。
- [x] PR の Reviewer の設定。
- [x] PR の Assignee の設定。
