### PR TITLE
シェア項目のテキスト修正

### DIFF
--- a/src/components/pages/DataShareAgree.tsx
+++ b/src/components/pages/DataShareAgree.tsx
@@ -25,8 +25,14 @@ export const DataShareAgreePage: FC = () => {
   const [isCheck, setIsCheck] = useState<boolean>(false);
   const [checkBoxError, setCheckBoxError] = useState(false);
 
-  const selectShare = [true,true,false,false]; //前の画面で選択されたデータの番号を受け取る
-  const agreeList = ['所得・個人住民税情報', '年金情報', '世帯情報', '医療保険情報'];
+  const selectShare = [true, true, false, false]; //前の画面で選択されたデータの番号を受け取る
+  const agreeList = [
+    '所得・個人住民税情報',
+    '国民年金・被用者年金の給付・保険料徴収の情報',
+    '銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報',
+    '住民票関係情報API',
+    '特定健診情報',
+  ];
 
   const checkHandle = () => {
     setIsCheck(!isCheck);
@@ -42,7 +48,9 @@ export const DataShareAgreePage: FC = () => {
             マイナポータルデモアプリのワクチン接種情報表示のためにマイナポータルを通じて、以下の情報を取得します。
           </Typography>
           <ul>
-            {agreeList.map((item, index) => (selectShare[index] ? <li key={item}>{item}</li> : null))}
+            {agreeList.map((item, index) =>
+              selectShare[index] ? <li key={item}>{item}</li> : null
+            )}
           </ul>
           <Typography variant="body1" style={{ marginBottom: '40px', marginTop: '40px' }}>
             マイナポータルの利用規約に同意いただき、上記情報をマイナポータルデモアプリに提供する場合、マイナンバーカードを利用した本人確認を行います。

--- a/src/components/pages/DataSharePage.tsx
+++ b/src/components/pages/DataSharePage.tsx
@@ -18,19 +18,23 @@ import { CommonButton } from '../common/CommonButton';
 
 const data = [
   {
-    label: '税・所得',
+    label: '所得・個人住民税情報',
     isCheck: false,
   },
   {
-    label: '年金',
+    label: '国民年金・被用者年金の給付・保険料徴収の情報',
     isCheck: false,
   },
   {
-    label: '世帯情報',
+    label: '銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報',
     isCheck: false,
   },
   {
-    label: '医療保険',
+    label: '住民票関係情報',
+    isCheck: false,
+  },
+  {
+    label: '特定健診情報',
     isCheck: false,
   },
 ];
@@ -108,20 +112,20 @@ export const DataSharePage: FC = () => {
             <Typography variant="body1" style={{ marginBottom: '20px' }}>
               他の人へ共有したいデータの種類を選択してください。{' '}
             </Typography>
-            <Typography variant="body1" style={{ fontWeight: 'bold' }}>
+            <Typography variant="body1" style={{ fontWeight: 'bold', marginBottom: '20px' }}>
               共有リンク <span style={{ color: '#FF0000' }}>必須</span>
             </Typography>
             <Stack>
               {CheckList.map((item, index) => {
                 return (
-                  <Box key={item.label}>
+                  <Box key={item.label} display="flex" alignItems="center" marginBottom="10px">
                     <Checkbox
                       checked={item.isCheck}
                       onChange={() => {
                         checkHandle(index);
                       }}
                     />
-                    {item.label}
+                    <Typography style={{ alignSelf: 'center' }}>{item.label}</Typography>
                   </Box>
                 );
               })}


### PR DESCRIPTION
データ共有画面と同意画面のシェア項目テキストをモックから修正

## 関連する issue\*

https://github.com/Yuma-Satake/My-Shienkin-Navi/issues/69

## 作業内容\*

データ共有画面と同意画面のシェア項目テキストをモックから修正

## チェックリスト\*

- [ ] 新規でのバグ・警告等がログに表示されていない。
- [ ] 本 PR に関係のない差分を含んでいない。
- [ ] この変更が他に影響を及ぼしていない。
- [ ] PR の Reviewer の設定。
- [ ] PR の Assignee の設定。

## スクリーンショット

<!-- UIの変更があれば -->
<!-- <img width="300px" src=""> -->
<img width="295" alt="スクリーンショット 2023-06-11 16 28 52" src="https://github.com/Yuma-Satake/My-Shienkin-Navi/assets/85344081/4c19238e-15f3-4c54-8896-35ab5f2ad2d9">
<img width="298" alt="スクリーンショット 2023-06-11 16 29 03" src="https://github.com/Yuma-Satake/My-Shienkin-Navi/assets/85344081/795f6437-84f0-490e-899a-fb7174d4d4e0">
