### PR TITLE
マイナポータルからデータを取得し、共有リンクを取得するまでのルーティングを実装

### DIFF
--- a/src/components/pages/ConfirmProvisionPage.tsx
+++ b/src/components/pages/ConfirmProvisionPage.tsx
@@ -35,10 +35,10 @@ export const ConfirmProvisionPage: FC = () => {
 
           <Box sx={{ marginTop: '40px', mx: 2, mt: 6 }}>
             <Col spacing={2}>
-              <CommonButton isPrimary onClick={() => navigate('/')}>
+              <CommonButton isPrimary onClick={() => navigate('/DataSharing')}>
                 データ取得
               </CommonButton>
-              <CommonButton isSecondary onClick={() => navigate('/DataTop')}>
+              <CommonButton isSecondary onClick={() => navigate('/SelectGettingDataPage')}>
                 キャンセル
               </CommonButton>
             </Col>

--- a/src/components/pages/DataShareAgree.tsx
+++ b/src/components/pages/DataShareAgree.tsx
@@ -80,12 +80,12 @@ export const DataShareAgreePage: FC = () => {
           <Box sx={{ marginTop: '30px', mx: 2, mt: 2 }}>
             <Col spacing={2}>
               <CommonButton
-                onClick={() => navigate('/DataShare')}
+                onClick={() => navigate('/PasswordEntry')}
                 isDisabled={nextButtonIsDisabled}
               >
                 次へ
               </CommonButton>
-              <CommonButton isSecondary onClick={() => navigate('/DataShare')}>
+              <CommonButton isSecondary onClick={() => navigate('/SelectGettingDataPage')}>
                 戻る
               </CommonButton>
             </Col>

--- a/src/components/pages/DataSharingPage.tsx
+++ b/src/components/pages/DataSharingPage.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { MainLayout } from '../layout/MainLayout';
 import { Box, Typography, TextField, Snackbar } from '@mui/material';
 import { CommonButton } from '../common/CommonButton';
@@ -10,6 +11,8 @@ type Props = {
 };
 
 export const DataSharingPage: FC<Props> = ({url}) => {
+  const navigate = useNavigate();
+
   const navList = [
     {
       label: 'リンクをコピー',
@@ -78,7 +81,7 @@ export const DataSharingPage: FC<Props> = ({url}) => {
               key={navList[1].label}
               isPrimary={navList[1].isPrimary}
               isSecondary={navList[1].isSecondary}
-              onClick={() => {}}
+              onClick={() => navigate('/DataTop')}
             >
               {navList[1].label}
             </CommonButton>

--- a/src/components/pages/DataTopPage.tsx
+++ b/src/components/pages/DataTopPage.tsx
@@ -12,7 +12,7 @@ export const DataTopPage: FC = () => {
   const navList = [
     {
       labele: 'データを共有する',
-      path: '/DataShare',
+      path: '/SelectGettingDataPage',
       isPrimary: true,
     },
     {

--- a/src/components/pages/PasswordEntryPage.tsx
+++ b/src/components/pages/PasswordEntryPage.tsx
@@ -52,12 +52,12 @@ export const PasswordEntryPage: FC = () => {
             <Col spacing={2}>
               <CommonButton
                 isDisabled={nextButtonIsDisabled}
-                onClick={() => navigate('/DataTop', { replace: true })}
+                onClick={() => navigate('/ConfirmProvision', { replace: true })}
               >
                 OK
               </CommonButton>
 
-              <CommonButton isSecondary onClick={() => navigate('/DataTop')}>
+              <CommonButton isSecondary onClick={() => navigate('/DataShareAgree')}>
                 キャンセル
               </CommonButton>
             </Col>

--- a/src/components/pages/SelectGettingDataPage.tsx
+++ b/src/components/pages/SelectGettingDataPage.tsx
@@ -47,7 +47,7 @@ interface ReceiveResultData {
   isShare: number; //0:最初の画面へ戻る、1:支援金の検索へ進む
 }
 
-export const DataSharePage: FC = () => {
+export const SelectGettingDataPage: FC = () => {
   const navigate = useNavigate();
 
   const [CheckList, setCheckList] = useState(data);
@@ -64,15 +64,8 @@ export const DataSharePage: FC = () => {
     isShare: 0,
   });
 
-  const handleSendData = () => {
-    setResultData({
-      title: '共有完了',
-      subText: 'データの共有が完了しました。',
-      isSuccess: true,
-      location: '/',
-      isShare: 0,
-    });
-    setResultPageIsShow(true);
+  const handleSelectGetData = () => {
+    navigate('/DataShareAgree')
   };
 
   const handleClose = () => {
@@ -153,11 +146,17 @@ export const DataSharePage: FC = () => {
             <DialogContentText>以下のデータを共有します。よろしいですか？</DialogContentText>
             <DialogContentText>
               <ul>
-                <li>データ名: XXXX</li>
+                {CheckList.map((item, index) => {
+                  if(item.isCheck) {
+                    return (
+                      <li>{item.label}</li>
+                    );
+                  }
+                })}
               </ul>
             </DialogContentText>
             <DialogActions>
-              <CommonButton onClick={handleSendData}>はい</CommonButton>
+              <CommonButton onClick={handleSelectGetData}>はい</CommonButton>
               <CommonButton isSecondary onClick={handleClose}>
                 いいえ
               </CommonButton>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -5,7 +5,7 @@ import { SupportSearchPage } from '../components/pages/SupportSearchPage';
 import { SupportListPage } from '../components/pages/SupportListPage';
 import { SupportDetailPage } from '../components/pages/SupportDetailPage';
 import { DataTopPage } from '../components/pages/DataTopPage';
-import { DataSharePage } from '../components/pages/DataSharePage';
+import { SelectGettingDataPage } from '../components/pages/SelectGettingDataPage';
 import { DataSharingPage } from '../components/pages/DataSharingPage';
 import { DataReceivePage } from '../components/pages/DataReceivePage';
 import { ErrorPage } from '../components/pages/ErrorPage';
@@ -25,7 +25,7 @@ export const Router: FC = () => {
         <Route path={'/SupportList'} element={<SupportListPage />} />
         <Route path={'/SupportDetail'} element={<SupportDetailPage />} />
         <Route path={'/DataTop'} element={<DataTopPage />} />
-        <Route path={'/DataShare'} element={<DataSharePage />} />
+        <Route path={'/SelectGettingDataPage'} element={<SelectGettingDataPage />} />
         <Route path={'/DataSharing'} element={<DataSharingPage url='sample.com' />} />
         <Route path={'/DataReceive'} element={<DataReceivePage />} />
         <Route path={'/MynaReceivePage4'} element={<MynaReceivePage4 />} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -25,15 +25,18 @@ export const Router: FC = () => {
         <Route path={'/SupportList'} element={<SupportListPage />} />
         <Route path={'/SupportDetail'} element={<SupportDetailPage />} />
         <Route path={'/DataTop'} element={<DataTopPage />} />
+
+        {/* データ共有に関わる一連のページ */}
         <Route path={'/SelectGettingDataPage'} element={<SelectGettingDataPage />} />
+        <Route path={'/DataShareAgree'} element={<DataShareAgreePage />} />
+        <Route path={'/PasswordEntry'} element={<PasswordEntryPage />} />
+        <Route path={'/ConfirmProvision'} element={<ConfirmProvisionPage />} />
         <Route path={'/DataSharing'} element={<DataSharingPage url='sample.com' />} />
+        
         <Route path={'/DataReceive'} element={<DataReceivePage />} />
         <Route path={'/MynaReceivePage4'} element={<MynaReceivePage4 />} />
         <Route path={'/dev'} element={<Dev />} />
-        <Route path={'/PasswordEntry'} element={<PasswordEntryPage />} />
         <Route path={'/*'} element={<ErrorPage />} />
-        <Route path={'/DataShareAgree'} element={<DataShareAgreePage />} />
-        <Route path={'/ConfirmProvision'} element={<ConfirmProvisionPage />} />
         <Route path={'/SampleLoading'} element={<SampleLoading />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## 関連する issue\*

Closes #72 

## 作業内容\*

`src\routes\Router.tsx`
`src\components\pages\SelectGettingDataPage.tsx`
`src\components\pages\DataShareAgree.tsx`
`src\components\pages\PasswordEntryPage.tsx`
`src\components\pages\ConfirmProvisionPage.tsx`
`src\components\pages\DataSharingPage.tsx`

## チェックリスト\*

- [x] 新規でのバグ・警告等がログに表示されていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [x] この変更が他に影響を及ぼしていない。
- [x] PR の Reviewer の設定。
- [x] PR の Assignee の設定。
