### PR TITLE
受け取りデータ確認画面へのルーティングを追加

### DIFF
--- a/src/components/pages/ConfirmProvisionPage.tsx
+++ b/src/components/pages/ConfirmProvisionPage.tsx
@@ -38,7 +38,7 @@ export const ConfirmProvisionPage: FC = () => {
               <CommonButton isPrimary onClick={() => navigate('/DataSharing')}>
                 データ取得
               </CommonButton>
-              <CommonButton isSecondary onClick={() => navigate('/SelectGettingDataPage')}>
+              <CommonButton isSecondary onClick={() => navigate('/SelectGettingData')}>
                 キャンセル
               </CommonButton>
             </Col>

--- a/src/components/pages/ConfirmProvisionPage.tsx
+++ b/src/components/pages/ConfirmProvisionPage.tsx
@@ -35,7 +35,7 @@ export const ConfirmProvisionPage: FC = () => {
 
           <Box sx={{ marginTop: '40px', mx: 2, mt: 6 }}>
             <Col spacing={2}>
-              <CommonButton isPrimary onClick={() => navigate('/DataSharing')}>
+              <CommonButton isPrimary onClick={() => navigate('/MynaReceivePage4')}>
                 データ取得
               </CommonButton>
               <CommonButton isSecondary onClick={() => navigate('/SelectGettingData')}>

--- a/src/components/pages/DataShareAgree.tsx
+++ b/src/components/pages/DataShareAgree.tsx
@@ -85,7 +85,7 @@ export const DataShareAgreePage: FC = () => {
               >
                 次へ
               </CommonButton>
-              <CommonButton isSecondary onClick={() => navigate('/SelectGettingDataPage')}>
+              <CommonButton isSecondary onClick={() => navigate('/SelectGettingData')}>
                 戻る
               </CommonButton>
             </Col>

--- a/src/components/pages/DataTopPage.tsx
+++ b/src/components/pages/DataTopPage.tsx
@@ -12,7 +12,7 @@ export const DataTopPage: FC = () => {
   const navList = [
     {
       labele: 'データを共有する',
-      path: '/SelectGettingDataPage',
+      path: '/SelectGettingData',
       isPrimary: true,
     },
     {

--- a/src/components/pages/MynaReceivePage4.tsx
+++ b/src/components/pages/MynaReceivePage4.tsx
@@ -13,7 +13,7 @@ export const MynaReceivePage4: FC = () => {
     {
       label: '共有リンク作成',
       isPrimary: true,
-      location: ""
+      location: "/DataSharing"
     },
   ];
 

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -27,7 +27,7 @@ export const Router: FC = () => {
         <Route path={'/DataTop'} element={<DataTopPage />} />
 
         {/* データ共有に関わる一連のページ */}
-        <Route path={'/SelectGettingDataPage'} element={<SelectGettingDataPage />} />
+        <Route path={'/SelectGettingData'} element={<SelectGettingDataPage />} />
         <Route path={'/DataShareAgree'} element={<DataShareAgreePage />} />
         <Route path={'/PasswordEntry'} element={<PasswordEntryPage />} />
         <Route path={'/ConfirmProvision'} element={<ConfirmProvisionPage />} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -31,10 +31,10 @@ export const Router: FC = () => {
         <Route path={'/DataShareAgree'} element={<DataShareAgreePage />} />
         <Route path={'/PasswordEntry'} element={<PasswordEntryPage />} />
         <Route path={'/ConfirmProvision'} element={<ConfirmProvisionPage />} />
+        <Route path={'/MynaReceivePage4'} element={<MynaReceivePage4 />} />
         <Route path={'/DataSharing'} element={<DataSharingPage url='sample.com' />} />
         
         <Route path={'/DataReceive'} element={<DataReceivePage />} />
-        <Route path={'/MynaReceivePage4'} element={<MynaReceivePage4 />} />
         <Route path={'/dev'} element={<Dev />} />
         <Route path={'/*'} element={<ErrorPage />} />
         <Route path={'/SampleLoading'} element={<SampleLoading />} />


### PR DESCRIPTION
## 関連する issue\*

Closes #72 

## 作業内容\*

`MynaReceivePage4`へのルーティングを設定

## チェックリスト\*

- [x] 新規でのバグ・警告等がログに表示されていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [x] この変更が他に影響を及ぼしていない。
- [x] PR の Reviewer の設定。
- [x] PR の Assignee の設定。
