### PR TITLE
SelectGettingDataPageからDataShareAgreeへのState管理

### DIFF
--- a/src/components/pages/DataShareAgree.tsx
+++ b/src/components/pages/DataShareAgree.tsx
@@ -17,6 +17,8 @@ import {
 import { Box } from '@mui/system';
 import { Col } from '../common/Col';
 import { CommonButton } from '../common/CommonButton';
+import { useRecoilValue } from 'recoil';
+import { SelectGettingDataState } from '../../hooks/SelectGettingDataState';
 
 export const DataShareAgreePage: FC = () => {
   const navigate = useNavigate();
@@ -24,15 +26,7 @@ export const DataShareAgreePage: FC = () => {
   const [nextButtonIsDisabled, setNextButtonIsDisabled] = useState<boolean>(true);
   const [isCheck, setIsCheck] = useState<boolean>(false);
   const [checkBoxError, setCheckBoxError] = useState(false);
-
-  const selectShare = [true, true, false, false]; //前の画面で選択されたデータの番号を受け取る
-  const agreeList = [
-    '所得・個人住民税情報',
-    '国民年金・被用者年金の給付・保険料徴収の情報',
-    '銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報',
-    '住民票関係情報API',
-    '特定健診情報',
-  ];
+  const CheckList = useRecoilValue(SelectGettingDataState);
 
   const checkHandle = () => {
     setIsCheck(!isCheck);
@@ -48,8 +42,8 @@ export const DataShareAgreePage: FC = () => {
             マイナポータルデモアプリのワクチン接種情報表示のためにマイナポータルを通じて、以下の情報を取得します。
           </Typography>
           <ul>
-            {agreeList.map((item, index) =>
-              selectShare[index] ? <li key={item}>{item}</li> : null
+            {CheckList.map((item, index) =>
+              item.isCheck ? <li key={item.id}>{item.label}</li> : null
             )}
           </ul>
           <Typography variant="body1" style={{ marginBottom: '40px', marginTop: '40px' }}>

--- a/src/components/pages/SelectGettingDataPage.tsx
+++ b/src/components/pages/SelectGettingDataPage.tsx
@@ -15,29 +15,8 @@ import {
 import { Box } from '@mui/system';
 import { Col } from '../common/Col';
 import { CommonButton } from '../common/CommonButton';
-
-const data = [
-  {
-    label: '所得・個人住民税情報',
-    isCheck: false,
-  },
-  {
-    label: '国民年金・被用者年金の給付・保険料徴収の情報',
-    isCheck: false,
-  },
-  {
-    label: '銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報',
-    isCheck: false,
-  },
-  {
-    label: '住民票関係情報',
-    isCheck: false,
-  },
-  {
-    label: '特定健診情報',
-    isCheck: false,
-  },
-];
+import { useRecoilState } from 'recoil';
+import { SelectGettingDataState, SelectGettingDataType } from '../../hooks/SelectGettingDataState';
 
 interface ReceiveResultData {
   title: string;
@@ -50,7 +29,7 @@ interface ReceiveResultData {
 export const SelectGettingDataPage: FC = () => {
   const navigate = useNavigate();
 
-  const [CheckList, setCheckList] = useState(data);
+  const [CheckList, setCheckList] = useRecoilState(SelectGettingDataState);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [checkBoxError, setCheckBoxError] = useState(false);
   const [nextButtonIsDisabled, setNextButtonIsDisabled] = useState<boolean>(true);
@@ -65,7 +44,7 @@ export const SelectGettingDataPage: FC = () => {
   });
 
   const handleSelectGetData = () => {
-    navigate('/DataShareAgree')
+    navigate('/DataShareAgree');
   };
 
   const handleClose = () => {
@@ -74,9 +53,10 @@ export const SelectGettingDataPage: FC = () => {
 
   const checkHandle = (index: number) => {
     let checkedFlag = false;
-    const setItem = CheckList.map((prevItem, activeIndex) => {
+    const setItem: SelectGettingDataType[] = CheckList.map((prevItem, activeIndex) => {
       if (index === activeIndex ? !prevItem.isCheck : prevItem.isCheck) checkedFlag = true;
       return {
+        id: prevItem.id,
         label: prevItem.label,
         isCheck: index === activeIndex ? !prevItem.isCheck : prevItem.isCheck,
       };
@@ -147,10 +127,8 @@ export const SelectGettingDataPage: FC = () => {
             <DialogContentText>
               <ul>
                 {CheckList.map((item, index) => {
-                  if(item.isCheck) {
-                    return (
-                      <li>{item.label}</li>
-                    );
+                  if (item.isCheck) {
+                    return <li>{item.label}</li>;
                   }
                 })}
               </ul>

--- a/src/hooks/SelectGettingDataState.ts
+++ b/src/hooks/SelectGettingDataState.ts
@@ -1,0 +1,40 @@
+import { atom } from 'recoil';
+
+export type SelectGettingDataType = {
+  id: number;
+  label: string;
+  isCheck: boolean;
+};
+
+const initialData: SelectGettingDataType[] = [
+  {
+    id: 1,
+    label: '所得・個人住民税情報',
+    isCheck: false,
+  },
+  {
+    id: 2,
+    label: '国民年金・被用者年金の給付・保険料徴収の情報',
+    isCheck: false,
+  },
+  {
+    id: 3,
+    label: '銀行名、支店名、口座番号、および口座名義カナなどの公金受取口座の情報',
+    isCheck: false,
+  },
+  {
+    id: 4,
+    label: '住民票関係情報',
+    isCheck: false,
+  },
+  {
+    id: 5,
+    label: '特定健診情報',
+    isCheck: false,
+  },
+];
+
+export const SelectGettingDataState = atom<SelectGettingDataType[]>({
+  key: 'SelectGettingDataState',
+  default: initialData,
+});


### PR DESCRIPTION
## 関連する issue\*
#75
<!--
次のいずれかを書いてください。
#issue番号（マージ時にまだ issue を close してはいけない場合）
Closes #番号（マージ時に issue を自動的に close させる場合）
-->

## 作業内容\*
SelectGettingDataPageで、セレクトした内容をDataShareAgreeへ持ち越すように改修
<!-- 変更箇所および内容 -->

## チェックリスト\*

- [x] 新規でのバグ・警告等がログに表示されていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [x] この変更が他に影響を及ぼしていない。
- [x] PR の Reviewer の設定。
- [x] PR の Assignee の設定。

## スクリーンショット

https://github.com/Yuma-Satake/My-Shienkin-Navi/assets/109256327/5e7de05e-16b0-4fa0-8fc0-7dc45cf9c2fb


<!-- UIの変更があれば -->
<!-- <img width="300px" src=""> -->
